### PR TITLE
Blockscout links for accounts and transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@web3-react/walletlink-connector": "^6.0.2",
     "copy-to-clipboard": "^3.2.0",
     "escape-string-regexp": "^2.0.0",
+    "eth-net-props": "^1.0.33",
     "ethers": "^4.0.44",
     "history": "^4.9.0",
     "i18next": "^15.0.9",

--- a/src/components/AccountDetails/Transaction.js
+++ b/src/components/AccountDetails/Transaction.js
@@ -3,7 +3,7 @@ import styled, { keyframes } from 'styled-components'
 import { Check } from 'react-feather'
 
 import { useWeb3React } from '../../hooks'
-import { getEtherscanLink } from '../../utils'
+import { getBlockscoutLink } from '../../utils'
 import { Link, Spinner } from '../../theme'
 import Copy from './Copy'
 import Circle from '../../assets/images/circle.svg'
@@ -80,12 +80,12 @@ export default function Transaction({ hash, pending }) {
   return (
     <TransactionWrapper key={hash}>
       <TransactionStatusWrapper>
-        <Link href={getEtherscanLink(chainId, hash, 'transaction')}>{hash} ↗ </Link>
+        <Link href={getBlockscoutLink(chainId, hash, 'transaction')}>{hash} ↗ </Link>
         <Copy toCopy={hash} />
       </TransactionStatusWrapper>
       {pending ? (
         <ButtonWrapper pending={pending}>
-          <Link href={getEtherscanLink(chainId, hash, 'transaction')}>
+          <Link href={getBlockscoutLink(chainId, hash, 'transaction')}>
             <TransactionState pending={pending}>
               <Spinner src={Circle} id="pending" />
               <TransactionStatusText>Pending</TransactionStatusText>
@@ -94,7 +94,7 @@ export default function Transaction({ hash, pending }) {
         </ButtonWrapper>
       ) : (
         <ButtonWrapper pending={pending}>
-          <Link href={getEtherscanLink(chainId, hash, 'transaction')}>
+          <Link href={getBlockscoutLink(chainId, hash, 'transaction')}>
             <TransactionState pending={pending}>
               <Check size="16" />
               <TransactionStatusText>Confirmed</TransactionStatusText>

--- a/src/components/AccountDetails/index.js
+++ b/src/components/AccountDetails/index.js
@@ -6,7 +6,7 @@ import Copy from './Copy'
 import Transaction from './Transaction'
 import { SUPPORTED_WALLETS } from '../../constants'
 import { ReactComponent as Close } from '../../assets/images/x.svg'
-import { getEtherscanLink } from '../../utils'
+import { getBlockscoutLink } from '../../utils'
 import { injected, walletconnect, walletlink, fortmatic, portis, torus } from '../../connectors'
 import CoinbaseWalletIcon from '../../assets/images/coinbaseWalletIcon.svg'
 import WalletConnectIcon from '../../assets/images/walletConnectIcon.svg'
@@ -338,14 +338,14 @@ export default function AccountDetails({
               <AccountGroupingRow>
                 {ENSName ? (
                   <AccountControl hasENS={!!ENSName} isENS={true}>
-                    <StyledLink hasENS={!!ENSName} isENS={true} href={getEtherscanLink(chainId, ENSName, 'address')}>
+                    <StyledLink hasENS={!!ENSName} isENS={true} href={getBlockscoutLink(chainId, ENSName, 'address')}>
                       {ENSName} ↗{' '}
                     </StyledLink>
                     <Copy toCopy={ENSName} />
                   </AccountControl>
                 ) : (
                   <AccountControl hasENS={!!ENSName} isENS={false}>
-                    <StyledLink hasENS={!!ENSName} isENS={false} href={getEtherscanLink(chainId, account, 'address')}>
+                    <StyledLink hasENS={!!ENSName} isENS={false} href={getBlockscoutLink(chainId, account, 'address')}>
                       {account} ↗{' '}
                     </StyledLink>
                     <Copy toCopy={account} />

--- a/src/components/WarningCard/index.js
+++ b/src/components/WarningCard/index.js
@@ -3,7 +3,7 @@ import styled, { keyframes } from 'styled-components'
 
 import { useWeb3React } from '../../hooks'
 import { useTokenDetails } from '../../contexts/Tokens'
-import { getEtherscanLink } from '../../utils'
+import { getBlockscoutLink } from '../../utils'
 
 import { Link } from '../../theme'
 import TokenLogo from '../TokenLogo'
@@ -166,8 +166,8 @@ function WarningCard({ onDismiss, urlAddedTokens, currency }) {
       <Row>
         <TokenLogo address={currency} />
         <div style={{ fontWeight: 500 }}>{inputName && inputSymbol ? inputName + ' (' + inputSymbol + ')' : ''}</div>
-        <Link style={{ fontWeight: 400 }} href={getEtherscanLink(chainId, currency, 'address')}>
-          (View on Etherscan)
+        <Link style={{ fontWeight: 400 }} href={getBlockscoutLink(chainId, currency, 'address')}>
+          (View on Blockscout)
         </Link>
       </Row>
       <Row style={{ fontSize: '12px', fontStyle: 'italic' }}>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,7 @@ import ERC20_ABI from '../constants/abis/erc20'
 import ERC20_BYTES32_ABI from '../constants/abis/erc20_bytes32'
 import { FACTORY_ADDRESSES, SUPPORTED_THEMES } from '../constants'
 import { formatFixed } from '@uniswap/sdk'
+import { explorerLinks } from 'eth-net-props'
 
 import UncheckedJsonRpcSigner from './signer'
 
@@ -44,6 +45,18 @@ export function getEtherscanLink(networkId, data, type) {
     case 'address':
     default: {
       return `${prefix}/address/${data}`
+    }
+  }
+}
+
+export function getBlockscoutLink(networkId, data, type) {
+  switch (type) {
+    case 'transaction': {
+      return explorerLinks.getExplorerTxLinkFor(data, networkId)
+    }
+    case 'address':
+    default: {
+      return explorerLinks.getExplorerAccountLinkFor(data, networkId)
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,6 +3001,11 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -4446,6 +4451,18 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chai@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -4478,6 +4495,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 checkpoint-store@^1.1.0:
   version "1.1.0"
@@ -5465,6 +5487,13 @@ decompress@^4.0.0:
     make-dir "^1.0.0"
     pify "^2.3.0"
     strip-dirs "^2.0.0"
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-equal@^1.0.1, deep-equal@~1.1.1:
   version "1.1.1"
@@ -6494,6 +6523,13 @@ eth-lib@^0.1.26:
     servify "^0.1.12"
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
+
+eth-net-props@^1.0.33:
+  version "1.0.33"
+  resolved "https://registry.yarnpkg.com/eth-net-props/-/eth-net-props-1.0.33.tgz#98b2abe1360593c86229bb131dde8a2c35a38763"
+  integrity sha512-RoqoXkY3+ztjdD9EfbjnMapWqfRjUscPon4Vjt48RLHDDYyNmz7LiQ4Qgb4E41PNS7xRoGkQCWJvJRAI9vDsFQ==
+  dependencies:
+    chai "^4.2.0"
 
 eth-query@^2.0.2, eth-query@^2.1.0, eth-query@^2.1.2:
   version "2.1.2"
@@ -7623,6 +7659,11 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -11614,6 +11655,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
@@ -15127,6 +15173,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Replace incorrect Etherscan link (since Etherscan has no support of xDai) to the relevant Blockscout link using `eth-net-props` npm package.